### PR TITLE
add 'Which children are you concerned about?' checkboxes

### DIFF
--- a/src/main/app/case/definition.ts
+++ b/src/main/app/case/definition.ts
@@ -2379,6 +2379,13 @@ export interface C1ASafteyConcernsAbuse{
   isOngoingBehaviour?:YesNoEmpty;
   seekHelpFromPersonOrAgency?: YesNoEmpty;
   seekHelpDetails?: string;
+  childrenConcernedAbout?: C1AChildrenConcernedAbout[];
+}
+
+export interface C1AChildrenConcernedAbout{
+  id: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface C1ASafteyConcerns {

--- a/src/main/app/case/definition.ts
+++ b/src/main/app/case/definition.ts
@@ -2379,13 +2379,7 @@ export interface C1ASafteyConcernsAbuse{
   isOngoingBehaviour?:YesNoEmpty;
   seekHelpFromPersonOrAgency?: YesNoEmpty;
   seekHelpDetails?: string;
-  childrenConcernedAbout?: C1AChildrenConcernedAbout[];
-}
-
-export interface C1AChildrenConcernedAbout{
-  id: string;
-  firstName: string;
-  lastName: string;
+  childrenConcernedAbout?: string;
 }
 
 export interface C1ASafteyConcerns {

--- a/src/main/steps/c100-rebuild/safety-concerns/child/report-abuse/content.test.ts
+++ b/src/main/steps/c100-rebuild/safety-concerns/child/report-abuse/content.test.ts
@@ -17,6 +17,8 @@ const en = {
               <p class="govuk-body ">You can <a href="https://www.gov.uk/injunction-domestic-violence" class="govuk-link govuk-link a" rel="external" target="_blank">apply for a domestic abuse injunction</a> separately.</p>`,
   warningText:
     'We will share the information that you give in this section with the other person in the case so that they can respond to what you have said.',
+  childrenConcernedAboutLabel: 'Which children are you concerned about? (optional)',
+  allChildrenLabel: 'All of the children in the application',
   behaviourDetailsLabel: 'Describe the behaviours you would like the court to be aware of. (optional)',
   behaviourDetailsHintText:
     'Keep your answer brief. You will have a chance to give more detail to the court later in the proceedings.',
@@ -48,6 +50,8 @@ const cy = {
               <p class="govuk-body ">You can <a href="https://www.gov.uk/injunction-domestic-violence" class="govuk-link govuk-link a" rel="external" target="_blank">apply for a domestic abuse injunction</a> separately. - Welsh</p>`,
   warningText:
     'We will share the information that you give in this section with the other person in the case so that they can respond to what you have said. - Welsh',
+  childrenConcernedAboutLabel: 'Which children are you concerned about? (optional) - Welsh',
+  allChildrenLabel: 'All of the children in the application - Welsh',
   behaviourDetailsLabel: 'Describe the behaviours you would like the court to be aware of. - Welsh (optional)',
   behaviourDetailsHintText:
     'Keep your answer brief. You will have a chance to give more detail to the court later in the proceedings. - Welsh',
@@ -74,6 +78,7 @@ describe('C1A safetyconcerns > child > report abuse > content', () => {
       c1A_safteyConcerns: {
         child: {
           physicalAbuse: {
+            childrenConcernedAbout: '',
             behaviourDetails: '',
             behaviourStartDate: '',
             isOngoingBehaviour: YesNoEmpty.YES,
@@ -122,11 +127,15 @@ describe('C1A safetyconcerns > child > report abuse > content', () => {
   });
 
   test('should contain report abuse form fields', () => {
+    const childrenConcernedAboutDetails = fields.childrenConcernedAbout as FormOptions;
     const behaviourDetails = fields.behaviourDetails as FormOptions;
     const behaviourStartDate = fields.behaviourStartDate as FormOptions;
     const isOngoingBehaviour = fields.isOngoingBehaviour as FormOptions;
     const seekHelpFromPersonOrAgency = fields.seekHelpFromPersonOrAgency as FormOptions;
     const seekHelpDetails = seekHelpFromPersonOrAgency.values[0].subFields!.seekHelpDetails as FormInput;
+
+    expect(childrenConcernedAboutDetails.type).toBe('checkboxes');
+    expect((childrenConcernedAboutDetails.label as Function)(generatedContent)).toBe(en.childrenConcernedAboutLabel);
 
     expect(behaviourDetails.type).toBe('textarea');
     expect((behaviourDetails.label as Function)(generatedContent)).toBe(en.behaviourDetailsLabel);

--- a/src/main/steps/c100-rebuild/safety-concerns/child/report-abuse/content.ts
+++ b/src/main/steps/c100-rebuild/safety-concerns/child/report-abuse/content.ts
@@ -94,20 +94,6 @@ export const generateFormFields = (
   data: C1ASafteyConcernsAbuse,
   childrenData: ChildrenDetails[]
 ): GenerateDynamicFormFields => {
-  let combinedChildren;
-  if (childrenData instanceof Array) {
-    combinedChildren = childrenData.map(childObj => {
-      return {
-        name: 'childrenConcernedAbout',
-        label: `${childObj.firstName} ${childObj.lastName}`,
-        value: JSON.stringify({
-          id: `${childObj.id}`,
-          firstName: `${childObj.firstName.trim()}`,
-          lastName: `${childObj.lastName.trim()}`,
-        }),
-      };
-    });
-  }
   const fields = {
     childrenConcernedAbout: {
       type: 'checkboxes',
@@ -119,9 +105,15 @@ export const generateFormFields = (
           name: 'childrenConcernedAbout',
           label: l => l.allChildrenLabel,
           exclusive: true,
-          value: combinedChildren.map(childObj => childObj.value),
+          value: childrenData.map(childObj => childObj.id).join(''),
         },
-        ...combinedChildren,
+        ...childrenData.map(childObj => {
+          return {
+            name: 'childrenConcernedAbout',
+            label: `${childObj.firstName} ${childObj.lastName}`,
+            value: `${childObj.id}`,
+          };
+        }),
       ],
     },
     behaviourDetails: {
@@ -187,6 +179,7 @@ export const generateFormFields = (
       ],
     },
   };
+
   const errors = {
     en: {},
     cy: {},
@@ -199,6 +192,12 @@ export const generateFormFields = (
   );
   fields.seekHelpFromPersonOrAgency.values = fields.seekHelpFromPersonOrAgency.values.map(config =>
     config.value === data.seekHelpFromPersonOrAgency ? { ...config, selected: true } : config
+  );
+
+  // mark the selection for the children checkboxes based on the option chosen
+  fields.childrenConcernedAbout.values = fields.childrenConcernedAbout.values.map(config =>
+    // Checking if the data.childrenConcernedAbout has been prefilled, if YES, data will be fetched from userCase. If NOT, checkboxes are made fresh and untouched
+    data.childrenConcernedAbout?.includes(config.value as string) ? { ...config, selected: true } : config
   );
 
   return { fields, errors };

--- a/src/main/steps/c100-rebuild/safety-concerns/child/report-abuse/content.ts
+++ b/src/main/steps/c100-rebuild/safety-concerns/child/report-abuse/content.ts
@@ -1,4 +1,4 @@
-import { C1AAbuseTypes, C1ASafteyConcernsAbuse, YesNoEmpty } from '../../../../../app/case/definition';
+import { C1AAbuseTypes, C1ASafteyConcernsAbuse, ChildrenDetails, YesNoEmpty } from '../../../../../app/case/definition';
 import { TranslationFn } from '../../../../../app/controller/GetController';
 import { FormContent, GenerateDynamicFormFields } from '../../../../../app/form/Form';
 import { getDataShape } from '../../util';
@@ -17,6 +17,8 @@ const en = () => ({
               <p class="govuk-body ">You can <a href="https://www.gov.uk/injunction-domestic-violence" class="govuk-link govuk-link a" rel="external" target="_blank">apply for a domestic abuse injunction</a> separately.</p>`,
   warningText:
     'We will share the information that you give in this section with the other person in the case so that they can respond to what you have said.',
+  childrenConcernedAboutLabel: 'Which children are you concerned about? (optional)',
+  allChildrenLabel: 'All of the children in the application',
   behaviourDetailsLabel: 'Describe the behaviours you would like the court to be aware of. (optional)',
   behaviourDetailsHintText:
     'Keep your answer brief. You will have a chance to give more detail to the court later in the proceedings.',
@@ -48,6 +50,8 @@ const cy = () => ({
               <p class="govuk-body ">You can <a href="https://www.gov.uk/injunction-domestic-violence" class="govuk-link govuk-link a" rel="external" target="_blank">apply for a domestic abuse injunction</a> separately. - Welsh</p>`,
   warningText:
     'We will share the information that you give in this section with the other person in the case so that they can respond to what you have said. - Welsh',
+  childrenConcernedAboutLabel: 'Which children are you concerned about? (optional) - Welsh',
+  allChildrenLabel: 'All of the children in the application - Welsh',
   behaviourDetailsLabel: 'Describe the behaviours you would like the court to be aware of. - Welsh (optional)',
   behaviourDetailsHintText:
     'Keep your answer brief. You will have a chance to give more detail to the court later in the proceedings. - Welsh',
@@ -86,8 +90,40 @@ const updateFormFields = (form: FormContent, formFields: FormContent['fields']):
   return updatedForm;
 };
 
-export const generateFormFields = (data: C1ASafteyConcernsAbuse): GenerateDynamicFormFields => {
+export const generateFormFields = (
+  data: C1ASafteyConcernsAbuse,
+  childrenData: ChildrenDetails[]
+): GenerateDynamicFormFields => {
+  let combinedChildren;
+  if (childrenData instanceof Array) {
+    combinedChildren = childrenData.map(childObj => {
+      return {
+        name: 'childrenConcernedAbout',
+        label: `${childObj.firstName} ${childObj.lastName}`,
+        value: JSON.stringify({
+          id: `${childObj.id}`,
+          firstName: `${childObj.firstName.trim()}`,
+          lastName: `${childObj.lastName.trim()}`,
+        }),
+      };
+    });
+  }
   const fields = {
+    childrenConcernedAbout: {
+      type: 'checkboxes',
+      classes: 'govuk-checkboxes',
+      labelSize: 's',
+      label: l => l.childrenConcernedAboutLabel,
+      values: [
+        {
+          name: 'childrenConcernedAbout',
+          label: l => l.allChildrenLabel,
+          exclusive: true,
+          value: combinedChildren.map(childObj => childObj.value),
+        },
+        ...combinedChildren,
+      ],
+    },
     behaviourDetails: {
       type: 'textarea',
       labelSize: 's',
@@ -191,7 +227,8 @@ export const generateContent: TranslationFn = content => {
   const translations = languages[content.language]();
   const abuseType: C1AAbuseTypes = content.additionalData!.req.params.abuseType;
   const sessionData: C1ASafteyConcernsAbuse = content.userCase?.c1A_safteyConcerns?.child?.[abuseType];
-  const { fields } = generateFormFields(sessionData ?? getDataShape().abuse);
+  const sessionChildrenData = content.userCase?.cd_children ?? [];
+  const { fields } = generateFormFields(sessionData ?? getDataShape().abuse, sessionChildrenData);
 
   return {
     ...translations,

--- a/src/main/steps/c100-rebuild/safety-concerns/util.ts
+++ b/src/main/steps/c100-rebuild/safety-concerns/util.ts
@@ -9,6 +9,7 @@ import {
 
 export const getDataShape = (): Record<string, any> => ({
   abuse: {
+    childrenConcernedAbout: '',
     behaviourDetails: '',
     behaviourStartDate: '',
     isOngoingBehaviour: YesNoEmpty.EMPTY,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRLC100-144


### Change description ###
- Added `Which children are you concerned about?(optional)` checkboxes on the page
- Children are dynamically rendered out depending on the number of children filled in on **child-details/add-children** URL


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
