### PR TITLE
PRL-5174: C100 confirmation screen content change

### DIFF
--- a/src/main/steps/c100-rebuild/confirmation-page/content.test.ts
+++ b/src/main/steps/c100-rebuild/confirmation-page/content.test.ts
@@ -6,7 +6,7 @@ import { generateContent } from './content';
 const en = {
   successMessage: 'Your application has been submitted',
   label: 'Case number',
-  subContent: "Your application has been sent to Central Family Court. You'll receive a confirmation email to",
+  subContent: "You'll receive a confirmation email to",
   subTitle1: 'Download a copy of your application',
   subTitle2: 'Now that you have submitted your application:',
   triTitle: 'You can also:',
@@ -37,7 +37,7 @@ const en = {
 const cy = {
   successMessage: 'Mae eich cais wedi ei gyflwyno',
   label: 'Rhif yr achos',
-  subContent: 'Mae eich cais wedi ei anfon i’r Llys Teulu Canolog. Fe anfonir e-bost i gadarnhau i',
+  subContent: 'Fe anfonir e-bost i gadarnhau i',
   subTitle1: 'Llwytho copi o’ch cais',
   subTitle2: 'Gan eich bod wedi cyflwyno eich cais:',
   triTitle: ' Gallwch hefyd:',

--- a/src/main/steps/c100-rebuild/confirmation-page/content.ts
+++ b/src/main/steps/c100-rebuild/confirmation-page/content.ts
@@ -7,7 +7,7 @@ import { appSurveyContents } from '../../../steps/common/app-survey/content';
 const en = () => ({
   successMessage: 'Your application has been submitted',
   label: 'Case number',
-  subContent: "Your application has been sent to Central Family Court. You'll receive a confirmation email to",
+  subContent: "You'll receive a confirmation email to",
   subTitle1: 'Download a copy of your application',
   subTitle2: 'Now that you have submitted your application:',
   triTitle: 'You can also:',
@@ -38,7 +38,7 @@ const en = () => ({
 const cy = () => ({
   successMessage: 'Mae eich cais wedi ei gyflwyno',
   label: 'Rhif yr achos',
-  subContent: 'Mae eich cais wedi ei anfon i’r Llys Teulu Canolog. Fe anfonir e-bost i gadarnhau i',
+  subContent: 'Fe anfonir e-bost i gadarnhau i',
   subTitle1: 'Llwytho copi o’ch cais',
   subTitle2: 'Gan eich bod wedi cyflwyno eich cais:',
   triTitle: ' Gallwch hefyd:',


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRL-5174


### Change description ###
Removes 'Your application has been sent Central family court' text from the C100 confirmation page.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
