### PR TITLE
Upgrade version of formidable to non-vulnerable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,8 @@
     "send": "0.19.1",
     "serve-static": "1.16.2",
     "cross-spawn": "7.0.6",
-    "cookie": "^0.7.2"
+    "cookie": "^0.7.2",
+    "formidable": "^3.5.4"
   },
   "packageManager": "yarn@4.6.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2444,6 +2444,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:^1.1.5":
+  version: 1.8.0
+  resolution: "@noble/hashes@npm:1.8.0"
+  checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -2747,6 +2754,15 @@ __metadata:
     ramda: "npm:^0.30.0"
     randexp: "npm:^0.5.3"
   checksum: 10c0/ad2262fb7cf41073963c5a39fe9e532b4247ed25a76be9cd4c0cb1caed99887b693381e72640d4bd1dd9a7d91fda85a0ae8e24a159f1e271a508572e37570e5e
+  languageName: node
+  linkType: hard
+
+"@paralleldrive/cuid2@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@paralleldrive/cuid2@npm:2.2.2"
+  dependencies:
+    "@noble/hashes": "npm:^1.1.5"
+  checksum: 10c0/af5826df93de437121308f4f4ce0b2eeb89b60bb57a1a6592fb89c0d40d311ad1d9f3f6a4db2cce6f2bcf572de1aa3f85704254e89b18ce61c41ebb06564c4ee
   languageName: node
   linkType: hard
 
@@ -9896,14 +9912,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"formidable@npm:^3.5.1":
-  version: 3.5.2
-  resolution: "formidable@npm:3.5.2"
+"formidable@npm:^3.5.4":
+  version: 3.5.4
+  resolution: "formidable@npm:3.5.4"
   dependencies:
+    "@paralleldrive/cuid2": "npm:^2.2.2"
     dezalgo: "npm:^1.0.4"
-    hexoid: "npm:^2.0.0"
     once: "npm:^1.4.0"
-  checksum: 10c0/c26d89ba84d392f0e68ba1aca9f779e0f2e94db053d95df562c730782956f302e3f069c07ab96f991415af915ac7b8771f4c813d298df43577fdf439e1e8741e
+  checksum: 10c0/3a311ce57617eb8f532368e91c0f2bbfb299a0f1a35090e085bd6ca772298f196fbb0b66f0d4b5549d7bf3c5e1844439338d4402b7b6d1fedbe206ad44a931f8
   languageName: node
   linkType: hard
 
@@ -10663,13 +10679,6 @@ __metadata:
   dependencies:
     hermes-estree: "npm:0.25.1"
   checksum: 10c0/3abaa4c6f1bcc25273f267297a89a4904963ea29af19b8e4f6eabe04f1c2c7e9abd7bfc4730ddb1d58f2ea04b6fee74053d8bddb5656ec6ebf6c79cc8d14202c
-  languageName: node
-  linkType: hard
-
-"hexoid@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "hexoid@npm:2.0.0"
-  checksum: 10c0/a9d5e6f4adeaefcb4a53803dd48bf0a242d92e8ec699555aea616c4bf8f91788f03093595085976f63d6830815dd080c063503540fabc7e854ebfb11161687c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Change description ###

- Manually upgraded version of formidable brought in by superagent to fix vulnerable version flagged in pipeline
- Passing smoke tests: https://build.hmcts.net/view/PRL/job/HMCTS_j_to_z/job/prl-e2e-tests/job/master/1033/

Vulnerability from nightly pipeline:
<img width="383" alt="Screenshot 2025-04-30 at 15 19 50" src="https://github.com/user-attachments/assets/ab87608e-d3e6-4c2b-a6c8-237a7c31c176" />


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
