### PR TITLE
Reduce all pipeline runs by ~2.5 mins by skipping duplicate test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "tsc --noEmit -p tsconfig.eslint.json && eslint . --ext .js,.ts",
     "build": "webpack --config webpack.config.js",
     "build:prod": "NODE_ENV=production webpack --mode production --config webpack.config.js",
-    "test": "jest",
+    "test": "npx if-env CI=true && exit 0 || yarn test:unit",
     "test:smoke": "echo 'Smoke test running in prl-e2e-test pipeline: https://build.hmcts.net/view/PRL/job/HMCTS_j_to_z/job/prl-e2e-tests/job/master/' && exit 0",
     "test:functional": "echo 'Functional tests running in prl-e2e-test nightly pipeline: https://build.hmcts.net/view/PRL/job/HMCTS_j_to_z_Nightly/job/prl-e2e-tests/job/master/' && exit 0",
     "fortifyScan": "./test/java/gradlew -p test/java fortifyScan",


### PR DESCRIPTION
Hi folks. This should make every pipeline run a bit quicker as you don't need to run `yarn test` followed by `yarn test:coverage`. Same set of tests twice for no reason.

Many other teams are doing this. Don't worry.