### PR TITLE
Fix js-yaml CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,8 @@
     "cross-spawn": "7.0.6",
     "cookie": "^0.7.2",
     "formidable": "^3.5.4",
-    "glob": "^9.0.0"
+    "glob": "^9.0.0",
+    "js-yaml": "^4.1.1"
   },
   "packageManager": "yarn@4.6.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5127,15 +5127,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"argparse@npm:^1.0.7":
-  version: 1.0.10
-  resolution: "argparse@npm:1.0.10"
-  dependencies:
-    sprintf-js: "npm:~1.0.2"
-  checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
-  languageName: node
-  linkType: hard
-
 "argparse@npm:^2.0.1":
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
@@ -8877,7 +8868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:^4.0.0, esprima@npm:^4.0.1":
+"esprima@npm:^4.0.1":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
   bin:
@@ -12308,26 +12299,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.1":
-  version: 3.14.1
-  resolution: "js-yaml@npm:3.14.1"
-  dependencies:
-    argparse: "npm:^1.0.7"
-    esprima: "npm:^4.0.0"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/6746baaaeac312c4db8e75fa22331d9a04cccb7792d126ed8ce6a0bbcfef0cedaddd0c5098fade53db067c09fe00aa1c957674b4765610a8b06a5a189e46433b
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "js-yaml@npm:4.1.0"
+"js-yaml@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "js-yaml@npm:4.1.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/184a24b4eaacfce40ad9074c64fd42ac83cf74d8c8cd137718d456ced75051229e5061b8633c3366b8aada17945a7a356b337828c19da92b51ae62126575018f
+  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
   languageName: node
   linkType: hard
 
@@ -17433,13 +17412,6 @@ __metadata:
   version: 1.1.3
   resolution: "sprintf-js@npm:1.1.3"
   checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:~1.0.2":
-  version: 1.0.3
-  resolution: "sprintf-js@npm:1.0.3"
-  checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Change description ###

Fix CVEs

08:54:39  Unsuppressed vulnerabilities found:
08:54:39  ├─ js-yaml: 4.1.0
08:54:39  │  ├─ ID: 1109802
08:54:39  │  ├─ Issue: js-yaml has prototype pollution in merge (<<)
08:54:39  │  ├─ URL: https://github.com/advisories/GHSA-mh29-5h37-fv8m
08:54:39  │  ├─ Severity: moderate
08:54:39  │  ├─ Vulnerable Versions: >= 4.0.0, < 4.1.1
08:54:39  │  ├─ Patched Versions: 4.1.1
08:54:39  │  ├─ Via: @hmcts/nodejs-healthcheck@npm:1.8.6
08:54:39  │  └─ Recommendation: Upgrade to 4.1.1
08:54:39  
08:54:39  ├─ js-yaml: 3.14.1
08:54:39  │  ├─ ID: 1109801
08:54:39  │  ├─ Issue: js-yaml has prototype pollution in merge (<<)
08:54:39  │  ├─ URL: https://github.com/advisories/GHSA-mh29-5h37-fv8m
08:54:39  │  ├─ Severity: moderate
08:54:39  │  ├─ Vulnerable Versions: >= 4.0.0, < 4.1.1
08:54:39  │  ├─ Patched Versions: 4.1.1
08:54:39  │  ├─ Via: @istanbuljs/load-nyc-config@npm:1.1.0
08:54:39  │  └─ Recommendation: Upgrade to 4.1.1



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
