### PR TITLE
fix: Fix maven central 429 "too many requests" error when running Fortify scan by pointing to artifactory first

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "jest",
     "test:smoke": "echo 'Smoke test running in prl-e2e-test pipeline: https://build.hmcts.net/view/PRL/job/HMCTS_j_to_z/job/prl-e2e-tests/job/master/' && exit 0",
     "test:functional": "echo 'Functional tests running in prl-e2e-test nightly pipeline: https://build.hmcts.net/view/PRL/job/HMCTS_j_to_z_Nightly/job/prl-e2e-tests/job/master/' && exit 0",
-    "fortifyScan": "./test/java/gradlew -p test/java fortifyScan --info",
+    "fortifyScan": "./test/java/gradlew -p test/java fortifyScan",
     "test:coverage": "jest --coverage",
     "test:a11y": "echo 'a11y tests will be executed after functional tests' && exit 0",
     "test:pa11y": "NODE_TLS_REJECT_UNAUTHORIZED=0 jest -c jest.a11y.config.js --maxWorkers 1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "jest",
     "test:smoke": "echo 'Smoke test running in prl-e2e-test pipeline: https://build.hmcts.net/view/PRL/job/HMCTS_j_to_z/job/prl-e2e-tests/job/master/' && exit 0",
     "test:functional": "echo 'Functional tests running in prl-e2e-test nightly pipeline: https://build.hmcts.net/view/PRL/job/HMCTS_j_to_z_Nightly/job/prl-e2e-tests/job/master/' && exit 0",
-    "fortifyScan": "./test/java/gradlew -p test/java fortifyScan",
+    "fortifyScan": "./test/java/gradlew -p test/java fortifyScan --info",
     "test:coverage": "jest --coverage",
     "test:a11y": "echo 'a11y tests will be executed after functional tests' && exit 0",
     "test:pa11y": "NODE_TLS_REJECT_UNAUTHORIZED=0 jest -c jest.a11y.config.js --maxWorkers 1",

--- a/test/java/build.gradle
+++ b/test/java/build.gradle
@@ -17,6 +17,7 @@ repositories {
     maven {
         url = uri('https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1')
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/test/java/build.gradle
+++ b/test/java/build.gradle
@@ -11,7 +11,9 @@ java {
 
 repositories {
     mavenLocal()
-    mavenCentral()
+    maven {
+      url = uri('https://artifactory.platform.hmcts.net/artifactory/maven-remotes')
+    }
     maven {
         url = uri('https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1')
     }


### PR DESCRIPTION
### Change description ###

- Add Artifactory maven repo above maven central to resolve dependencies via Artifactory before maven central to avoid too many requests to maven central

Nightly-dev build passing:
<img width="912" height="236" alt="Screenshot 2026-05-08 at 09 15 08" src="https://github.com/user-attachments/assets/496deae4-ca74-47b7-9523-eb5fa2e93f62" />


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
