### PR TITLE
Created two 'buckets' that should allow renovate to create high secur…

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,17 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>hmcts/.github:renovate-config", "local>hmcts/.github//renovate/automerge-minor"],
-  "prConcurrentLimit": 15,
+  "extends": [
+    "local>hmcts/.github:renovate-config",
+    "local>hmcts/.github//renovate/automerge-minor"],
+  "prConcurrentLimit": 25,
   "schedule": ["after 4pm and before 7pm every weekday"],
   "rebaseWhen": "behind-base-branch",
   "packageRules": [
     {
-      "description": "Trigger security fixes immediately and bypass the concurrency limit",
       "matchVulnerabilities": true,
-      "schedule": null,
+      "description": "VIP Lane: Allow up to 25 total PRs if they are security fixes",
+      "schedule": "at any time",
       "dependencyDashboardApproval": false,
-      "prConcurrentLimit": 25,
       "commitMessagePrefix": "SEC-FIX: "
+    },
+    {
+      "matchVulnerabilities": false,
+      "description": "Standard Lane: Cap non-security PRs at 15",
+      "prConcurrentLimit": 15
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,22 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>hmcts/.github:renovate-config",
-    "local>hmcts/.github//renovate/automerge-minor"],
+  "extends": ["local>hmcts/.github:renovate-config", "local>hmcts/.github//renovate/automerge-minor"],
+  "osvVulnerabilityAlerts": true,
   "prConcurrentLimit": 25,
   "schedule": ["after 4pm and before 7pm every weekday"],
   "rebaseWhen": "behind-base-branch",
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": "at any time",
+    "prConcurrentLimit": 25,
+    "vulnerabilityFixStrategy": "lowest",
+    "dependencyDashboardApproval": false,
+    "commitMessagePrefix": "SEC-FIX: "
+  },
   "packageRules": [
     {
-      "matchVulnerabilities": true,
-      "description": "VIP Lane: Allow up to 25 total PRs if they are security fixes",
-      "schedule": "at any time",
-      "dependencyDashboardApproval": false,
-      "commitMessagePrefix": "SEC-FIX: "
-    },
-    {
-      "matchVulnerabilities": false,
-      "description": "Standard Lane: Cap non-security PRs at 15",
+      "matchPackageNames": ["*"],
+      "description": "Standard Lane: Limit non-vulnerability PRs to 15",
       "prConcurrentLimit": 15
     }
   ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A

### Change description ###

This PR updates our renovate.json to create a "VIP Lane" for security vulnerabilities. It ensures that critical security patches are never blocked by our concurrency limits, while keeping routine dependency updates capped at a manageable level.

We are moving from a single flat limit to a tiered concurrency model:

Standard Updates (Non-Security): Capped at 15 open PRs. This maintains our current "Normal" noise level so the team isn't overwhelmed by routine version bumps.

Security Fixes (Vulnerabilities): These now bypass the standard schedule and have a higher ceiling of 25 total open PRs.

Global Ceiling: The absolute maximum number of open Renovate PRs is now 25, but the extra 10 slots are exclusively reserved for security patches.

Link to renovate docs. I used this to refine the config:
https://docs.renovatebot.com/configuration-options/


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
