### PR TITLE
FPVTL-2528: Skip respondent confidentiality screens when only 1 respondent exists

### DIFF
--- a/src/main/steps/c100-rebuild/c100sequence.test.ts
+++ b/src/main/steps/c100-rebuild/c100sequence.test.ts
@@ -1,11 +1,11 @@
 import { applicantMockRequest } from '../../../test/unit/mocks/mocked-requests/applicant-details-mock';
 import { childrenMockData } from '../../../test/unit/mocks/mocked-requests/child-details-mock';
 import { miamMockData } from '../../../test/unit/mocks/mocked-requests/miam-mock';
+import { multipleRespondentsMockData } from '../../../test/unit/mocks/mocked-requests/multiple-respondents-details-mock';
 import { otherChildrenMockData } from '../../../test/unit/mocks/mocked-requests/other-child-mock';
 import { otherPersonMockData } from '../../../test/unit/mocks/mocked-requests/other-person-mock';
 import { otherProceedingsMockData } from '../../../test/unit/mocks/mocked-requests/other-proceedings-mock';
 import { respondentMockData } from '../../../test/unit/mocks/mocked-requests/respondent-details-mock';
-import { multipleRespondentsMockData } from '../../../test/unit/mocks/mocked-requests/multiple-respondents-details-mock';
 import { CaseWithId, Miam_urgency } from '../../app/case/case';
 import { MiamNonAttendReason, YesOrNo } from '../../app/case/definition';
 import { AppRequest } from '../../app/controller/AppRequest';
@@ -886,9 +886,9 @@ describe('C100Sequence', () => {
 
     expect(C100Sequence[84].url).toBe('/c100-rebuild/respondent-details/:respondentId/contact-details');
     expect(C100Sequence[84].showInSection).toBe('c100');
-    expect(C100Sequence[84].getNextStep(multipleRespondentsMockData.session.userCase, multipleRespondentsMockData)).toBe(
-      '/c100-rebuild/respondent-details/2732dd53-2e6c-46f9-88cd-08230e735b08/confidentiality/start-alternative'
-    );
+    expect(
+      C100Sequence[84].getNextStep(multipleRespondentsMockData.session.userCase, multipleRespondentsMockData)
+    ).toBe('/c100-rebuild/respondent-details/2732dd53-2e6c-46f9-88cd-08230e735b08/confidentiality/start-alternative');
 
     expect(C100Sequence[85].url).toBe(
       '/c100-rebuild/respondent-details/:respondentId/confidentiality/start-alternative'

--- a/src/main/steps/c100-rebuild/c100sequence.test.ts
+++ b/src/main/steps/c100-rebuild/c100sequence.test.ts
@@ -5,6 +5,7 @@ import { otherChildrenMockData } from '../../../test/unit/mocks/mocked-requests/
 import { otherPersonMockData } from '../../../test/unit/mocks/mocked-requests/other-person-mock';
 import { otherProceedingsMockData } from '../../../test/unit/mocks/mocked-requests/other-proceedings-mock';
 import { respondentMockData } from '../../../test/unit/mocks/mocked-requests/respondent-details-mock';
+import { multipleRespondentMockData } from '../../../test/unit/mocks/mocked-requests/multiple-respondent-details-mock';
 import { CaseWithId, Miam_urgency } from '../../app/case/case';
 import { MiamNonAttendReason, YesOrNo } from '../../app/case/definition';
 import { AppRequest } from '../../app/controller/AppRequest';
@@ -885,7 +886,7 @@ describe('C100Sequence', () => {
 
     expect(C100Sequence[84].url).toBe('/c100-rebuild/respondent-details/:respondentId/contact-details');
     expect(C100Sequence[84].showInSection).toBe('c100');
-    expect(C100Sequence[84].getNextStep(respondentMockData.session.userCase, respondentMockData)).toBe(
+    expect(C100Sequence[84].getNextStep(multipleRespondentMockData.session.userCase, multipleRespondentMockData)).toBe(
       '/c100-rebuild/respondent-details/2732dd53-2e6c-46f9-88cd-08230e735b08/confidentiality/start-alternative'
     );
 

--- a/src/main/steps/c100-rebuild/c100sequence.test.ts
+++ b/src/main/steps/c100-rebuild/c100sequence.test.ts
@@ -5,7 +5,7 @@ import { otherChildrenMockData } from '../../../test/unit/mocks/mocked-requests/
 import { otherPersonMockData } from '../../../test/unit/mocks/mocked-requests/other-person-mock';
 import { otherProceedingsMockData } from '../../../test/unit/mocks/mocked-requests/other-proceedings-mock';
 import { respondentMockData } from '../../../test/unit/mocks/mocked-requests/respondent-details-mock';
-import { multipleRespondentMockData } from '../../../test/unit/mocks/mocked-requests/multiple-respondent-details-mock';
+import { multipleRespondentsMockData } from '../../../test/unit/mocks/mocked-requests/multiple-respondents-details-mock';
 import { CaseWithId, Miam_urgency } from '../../app/case/case';
 import { MiamNonAttendReason, YesOrNo } from '../../app/case/definition';
 import { AppRequest } from '../../app/controller/AppRequest';
@@ -886,7 +886,7 @@ describe('C100Sequence', () => {
 
     expect(C100Sequence[84].url).toBe('/c100-rebuild/respondent-details/:respondentId/contact-details');
     expect(C100Sequence[84].showInSection).toBe('c100');
-    expect(C100Sequence[84].getNextStep(multipleRespondentMockData.session.userCase, multipleRespondentMockData)).toBe(
+    expect(C100Sequence[84].getNextStep(multipleRespondentsMockData.session.userCase, multipleRespondentsMockData)).toBe(
       '/c100-rebuild/respondent-details/2732dd53-2e6c-46f9-88cd-08230e735b08/confidentiality/start-alternative'
     );
 

--- a/src/main/steps/c100-rebuild/respondent-details/navigationController.test.ts
+++ b/src/main/steps/c100-rebuild/respondent-details/navigationController.test.ts
@@ -305,7 +305,7 @@ describe('RespondentsDetailsNavigationController', () => {
     ).toBe('/c100-rebuild/respondent-details/2732dd53-2e6c-46f9-88cd-08230e735b08/contact-details');
   });
 
-  test('From Respondent contact details screen -> navigate to Other Person check screen when less than one respondent exists', async () => {
+  test('From Respondent contact details screen -> navigate to Other Person check screen when just one respondent exists', async () => {
     const dummyparams = mockRequest({
       params: {
         respondentId: '2732dd53-2e6c-46f9-88cd-08230e735b08',

--- a/src/main/steps/c100-rebuild/respondent-details/navigationController.test.ts
+++ b/src/main/steps/c100-rebuild/respondent-details/navigationController.test.ts
@@ -164,6 +164,64 @@ const dummyRequest = mockRequest({
   },
 });
 
+const dummyRequestWithOneRespondent = mockRequest({
+  params: {
+    respondentId: '2732dd53-2e6c-46f9-88cd-08230e735b08',
+  },
+  session: {
+    userCase: {
+      resp_Respondents: [
+        {
+          id: '2732dd53-2e6c-46f9-88cd-08230e735b08',
+          firstName: 'r1',
+          lastName: 'r11',
+          personalDetails: {
+            dateOfBirth: {
+              day: '',
+              month: '',
+              year: '',
+            },
+            isDateOfBirthUnknown: '',
+            approxDateOfBirth: {
+              day: '',
+              month: '',
+              year: '',
+            },
+            gender: '',
+            otherGenderDetails: '',
+          },
+          contactDetails: {
+            donKnowEmailAddress: 'No',
+            emailAddress: 'email@example.com',
+            telephoneNumber: '00000000000',
+            donKnowTelephoneNumber: 'No',
+          },
+          relationshipDetails: {
+            relationshipToChildren: [
+              {
+                relationshipType: 'Mother',
+                childId: '20bda557-4d03-49c1-a3a4-a313431dc96d',
+                otherRelationshipTypeDetails: '',
+              },
+              {
+                childId: 'eb609a11-a5f0-4cee-85ce-5670b58ca767',
+                relationshipType: 'Father',
+                otherRelationshipTypeDetails: '',
+              },
+              {
+                childId: '00e40672-de9f-4361-8b83-f5104d9aa11a',
+                relationshipType: 'Guardian',
+                otherRelationshipTypeDetails: '',
+              },
+            ],
+          },
+          isRespondentEmailAddressConfidential: 'Yes',
+        },
+      ],
+    },
+  },
+});
+
 describe('RespondentsDetailsNavigationController', () => {
   test('From Add Respondent screen -> navigate to Respondent details screen', async () => {
     expect(
@@ -247,7 +305,22 @@ describe('RespondentsDetailsNavigationController', () => {
     ).toBe('/c100-rebuild/respondent-details/2732dd53-2e6c-46f9-88cd-08230e735b08/contact-details');
   });
 
-  test('From Respondent contact details screen -> navigate to Respondent confidentiality start screen', async () => {
+  test('From Respondent contact details screen -> navigate to Other Person check screen when less than one respondent exists', async () => {
+    const dummyparams = mockRequest({
+      params: {
+        respondentId: '2732dd53-2e6c-46f9-88cd-08230e735b08',
+      },
+    });
+    expect(
+      RespondentsDetailsNavigationController.getNextUrl(
+        C100_RESPONDENT_DETAILS_CONTACT_DETAILS,
+        dummyRequestWithOneRespondent.session.userCase,
+        dummyparams.params
+      )
+    ).toBe('/c100-rebuild/other-person-details/other-person-check');
+  });
+
+  test('From Respondent contact details screen -> navigate to Respondent confidentiality start screen when more than one respondent exists', async () => {
     const dummyparams = mockRequest({
       params: {
         childId: '7483640e-0817-4ddc-b709-6723f7925635',
@@ -311,7 +384,7 @@ describe('RespondentsDetailsNavigationController', () => {
     ).toBe('/c100-rebuild/respondent-details/2cd885a0-135e-45f1-85b7-aa46a1f78f46/personal-details');
   });
 
-  test('From Respondent confidentiality feedback no screen -> navigate to other person check screen when no other respondents exist', async () => {
+  test('From Respondent confidentiality feedback no screen -> navigate to other person check screen when no further respondents exist', async () => {
     const dummyparams = mockRequest({
       params: {
         childId: '7483640e-0817-4ddc-b709-6723f7925635',

--- a/src/main/steps/c100-rebuild/respondent-details/navigationController.ts
+++ b/src/main/steps/c100-rebuild/respondent-details/navigationController.ts
@@ -81,8 +81,9 @@ class RespondentsDetailsNavigationController {
         const hasEmail = currentRespondent?.contactDetails?.donKnowEmailAddress !== YesOrNo.YES;
         const hasPhone = currentRespondent?.contactDetails?.donKnowTelephoneNumber !== YesOrNo.YES;
         const hasAddress = currentRespondent?.address?.AddressLine1;
+        const hasMoreThanOneRespondent = this.respondentsDetails.length > 1;
 
-        if (currentRespondent && (hasEmail || hasPhone || hasAddress)) {
+        if (currentRespondent && hasMoreThanOneRespondent && (hasEmail || hasPhone || hasAddress)) {
           nextUrl = applyParms(C100_RESPONDENT_DETAILS_CONFIDENTIALITY_START_ALTERNATIVE, {
             respondentId: this.respondentId,
           });

--- a/src/test/unit/mocks/mocked-requests/multiple-respondent-details-mock.ts
+++ b/src/test/unit/mocks/mocked-requests/multiple-respondent-details-mock.ts
@@ -1,0 +1,121 @@
+import { mockRequest } from '../../utils/mockRequest';
+
+export const multipleRespondentMockData = mockRequest({
+  params: {
+    childId: '7483640e-0817-4ddc-b709-6723f7925474',
+    respondentId: '2732dd53-2e6c-46f9-88cd-08230e735b08',
+  },
+  session: {
+    userCase: {
+      cd_children: [
+        {
+          id: '7483640e-0817-4ddc-b709-6723f7925474',
+          firstName: 'Bob',
+          lastName: 'Silly',
+          personalDetails: {
+            dateOfBirth: {
+              year: '',
+              month: '',
+              day: '',
+            },
+            isDateOfBirthUnknown: '',
+            approxDateOfBirth: {
+              year: '',
+              month: '',
+              day: '',
+            },
+            sex: '',
+          },
+          childMatters: {
+            needsResolution: [],
+          },
+          parentialResponsibility: {
+            statement: '',
+          },
+        },
+      ],
+      resp_Respondents: [
+        {
+          id: '2732dd53-2e6c-46f9-88cd-08230e735b08',
+          firstName: 'r1',
+          lastName: 'r11',
+          personalDetails: {
+            dateOfBirth: {
+              day: '',
+              month: '',
+              year: '',
+            },
+            isDateOfBirthUnknown: '',
+            approxDateOfBirth: {
+              day: '',
+              month: '',
+              year: '',
+            },
+            gender: '',
+            otherGenderDetails: '',
+          },
+          relationshipDetails: {
+            relationshipToChildren: [
+              {
+                relationshipType: 'Mother',
+                childId: '20bda557-4d03-49c1-a3a4-a313431dc96d',
+                otherRelationshipTypeDetails: '',
+              },
+              {
+                childId: 'eb609a11-a5f0-4cee-85ce-5670b58ca767',
+                relationshipType: 'Father',
+                otherRelationshipTypeDetails: '',
+              },
+              {
+                childId: '00e40672-de9f-4361-8b83-f5104d9aa11a',
+                relationshipType: 'Guardian',
+                otherRelationshipTypeDetails: '',
+              },
+            ],
+          },
+          isRespondentAddressConfidential: 'Yes',
+        },
+        {
+          id: '2cd885a0-135e-45f1-85b7-aa46a1f78f46',
+          firstName: 'r2',
+          lastName: 'r22',
+          personalDetails: {
+            dateOfBirth: {
+              day: '',
+              month: '',
+              year: '',
+            },
+            isDateOfBirthUnknown: '',
+            approxDateOfBirth: {
+              day: '',
+              month: '',
+              year: '',
+            },
+            gender: '',
+            otherGenderDetails: '',
+          },
+          relationshipDetails: {
+            relationshipToChildren: [
+              {
+                relationshipType: 'Mother',
+                childId: '20bda557-4d03-49c1-a3a4-a313431dc96d',
+                otherRelationshipTypeDetails: '',
+              },
+              {
+                childId: 'eb609a11-a5f0-4cee-85ce-5670b58ca767',
+                relationshipType: 'Father',
+                otherRelationshipTypeDetails: '',
+              },
+              {
+                childId: '00e40672-de9f-4361-8b83-f5104d9aa11a',
+                relationshipType: 'Guardian',
+                otherRelationshipTypeDetails: '',
+              },
+            ],
+          },
+          isRespondentAddressConfidential: 'Yes',
+        },
+      ],
+    },
+  },
+});

--- a/src/test/unit/mocks/mocked-requests/multiple-respondents-details-mock.ts
+++ b/src/test/unit/mocks/mocked-requests/multiple-respondents-details-mock.ts
@@ -1,6 +1,6 @@
 import { mockRequest } from '../../utils/mockRequest';
 
-export const multipleRespondentMockData = mockRequest({
+export const multipleRespondentsMockData = mockRequest({
   params: {
     childId: '7483640e-0817-4ddc-b709-6723f7925474',
     respondentId: '2732dd53-2e6c-46f9-88cd-08230e735b08',


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPVTL-2528

### Change description ###

Skip respondent confidentiality screens when only 1 respondent exists

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```