### PR TITLE
FPVTL-2270: Enable the new confidentiality question (respondents) to show on the CYA page

### DIFF
--- a/src/main/steps/c100-rebuild/check-your-answers/mainUtil.test.ts
+++ b/src/main/steps/c100-rebuild/check-your-answers/mainUtil.test.ts
@@ -128,6 +128,8 @@ const keys = {
     'Do you want to keep {firstName} {lastName}’s contact details private from the other people named in the application (the respondents)?',
   doYouWantToKeep: 'Do the other people named in the application (the respondents) know any contact details of {name}?',
   courtOrderPrevent: 'courtOrderPrevent',
+  doYouWantToKeepResp:
+    "Do you want to request to keep {firstName} {lastName}'s contact details private from the other people named in the application?",
 };
 const language = 'en';
 const content = {
@@ -2178,6 +2180,27 @@ describe('test cases for main util', () => {
         value: {
           html: '+447205308786',
           text: '+447205308786',
+        },
+      },
+      {
+        actions: {
+          items: [
+            {
+              href: '/c100-rebuild/respondent-details/974b73a9-730e-4db0-b703-19ed3eab0342/confidentiality/start-alternative',
+              text: undefined,
+              visuallyHiddenText:
+                "respondents 1 Do you want to request to keep Respondent FirstPage's contact details private from the other people named in the application?",
+              attributes: {
+                id: 'doYouWantToKeep-respondent-0',
+              },
+            },
+          ],
+        },
+        key: {
+          text: "Do you want to request to keep Respondent FirstPage's contact details private from the other people named in the application?",
+        },
+        value: {
+          html: '<dl class="govuk-summary-list"><div class="govuk-summary-list__row border-bottom--none"><dd class="govuk-summary-list__value"><span class="govuk-error-message">Complete this section</span></dl>',
         },
       },
     ]);

--- a/src/main/steps/c100-rebuild/check-your-answers/mainUtil.test.ts
+++ b/src/main/steps/c100-rebuild/check-your-answers/mainUtil.test.ts
@@ -2182,29 +2182,141 @@ describe('test cases for main util', () => {
           text: '+447205308786',
         },
       },
-      {
-        actions: {
-          items: [
-            {
-              href: '/c100-rebuild/respondent-details/974b73a9-730e-4db0-b703-19ed3eab0342/confidentiality/start-alternative',
-              text: undefined,
-              visuallyHiddenText:
-                "respondents 1 Do you want to request to keep Respondent FirstPage's contact details private from the other people named in the application?",
-              attributes: {
-                id: 'doYouWantToKeep-respondent-0',
-              },
-            },
-          ],
-        },
-        key: {
-          text: "Do you want to request to keep Respondent FirstPage's contact details private from the other people named in the application?",
-        },
-        value: {
-          html: '<dl class="govuk-summary-list"><div class="govuk-summary-list__row border-bottom--none"><dd class="govuk-summary-list__value"><span class="govuk-error-message">Complete this section</span></dl>',
-        },
-      },
     ]);
     expect(respondentDetailsObj?.title).toBe('');
+  });
+
+  test('Confidential questions are mandatory for multiple respondents', () => {
+    const userCase = {
+      id: 'id',
+      state: undefined,
+      resp_Respondents: [
+        {
+          id: '974b73a9-730e-4db0-b703-19ed3eab0342',
+          firstName: 'Respondent',
+          lastName: 'FirstPage',
+          personalDetails: {
+            dateOfBirth: {
+              year: '1999',
+              month: '01',
+              day: '11',
+            },
+            isDateOfBirthUnknown: 'Yes',
+            approxDateOfBirth: {
+              day: '',
+              month: '',
+              year: '',
+            },
+            gender: 'Male',
+            otherGenderDetails: '',
+            hasNameChanged: 'no',
+            previousFullName: '',
+            respondentPlaceOfBirth: 'ok',
+            respondentPlaceOfBirthUnknown: 'Yes',
+          },
+          address: {
+            AddressLine1: 'dsadas',
+            AddressLine2: '',
+            PostTown: 'ILFORD',
+            County: '',
+            PostCode: '',
+            Country: 'United Kingdom',
+            addressHistory: 'dontKnow',
+            provideDetailsOfPreviousAddresses: '',
+          },
+          relationshipDetails: {
+            relationshipToChildren: [
+              {
+                childId: '39bc0ed2-503e-4d6e-a957-b57e8f35bc70',
+                relationshipType: 'Other',
+                otherRelationshipTypeDetails: '',
+              },
+            ],
+          },
+          contactDetails: {
+            emailAddress: 'abc@gmail.com',
+            telephoneNumber: '+447205308786',
+          },
+        },
+        {
+          id: '974b73a9-730e-4db0-b703-19ed3eab0342',
+          firstName: 'Respondent',
+          lastName: 'SecondPage',
+          personalDetails: {
+            dateOfBirth: {
+              year: '1999',
+              month: '01',
+              day: '11',
+            },
+            isDateOfBirthUnknown: 'Yes',
+            approxDateOfBirth: {
+              day: '',
+              month: '',
+              year: '',
+            },
+            gender: 'Male',
+            otherGenderDetails: '',
+            hasNameChanged: 'no',
+            previousFullName: '',
+            respondentPlaceOfBirth: 'ok',
+            respondentPlaceOfBirthUnknown: 'Yes',
+          },
+          address: {
+            AddressLine1: 'dsadas',
+            AddressLine2: '',
+            PostTown: 'ILFORD',
+            County: '',
+            PostCode: '',
+            Country: 'United Kingdom',
+            addressHistory: 'dontKnow',
+            provideDetailsOfPreviousAddresses: '',
+          },
+          relationshipDetails: {
+            relationshipToChildren: [
+              {
+                childId: '39bc0ed2-503e-4d6e-a957-b57e8f35bc70',
+                relationshipType: 'Other',
+                otherRelationshipTypeDetails: '',
+              },
+            ],
+          },
+          contactDetails: {
+            emailAddress: 'abc@gmail.com',
+            telephoneNumber: '+447205308786',
+          },
+        },
+      ],
+      cd_children: [
+        {
+          id: '39bc0ed2-503e-4d6e-a957-b57e8f35bc70',
+          firstName: 'Nir',
+          lastName: 'Sin',
+        },
+      ],
+    } as ANYTYPE;
+
+    const respondentDetailsObj = RespondentDetails({ sectionTitles, keys, content }, userCase, language);
+    expect(respondentDetailsObj?.rows).toContainEqual({
+      actions: {
+        items: [
+          {
+            href: '/c100-rebuild/respondent-details/974b73a9-730e-4db0-b703-19ed3eab0342/confidentiality/start-alternative',
+            text: undefined,
+            visuallyHiddenText:
+              "respondents 1 Do you want to request to keep Respondent FirstPage's contact details private from the other people named in the application?",
+            attributes: {
+              id: 'doYouWantToKeep-respondent-0',
+            },
+          },
+        ],
+      },
+      key: {
+        text: "Do you want to request to keep Respondent FirstPage's contact details private from the other people named in the application?",
+      },
+      value: {
+        html: '<dl class="govuk-summary-list"><div class="govuk-summary-list__row border-bottom--none"><dd class="govuk-summary-list__value"><span class="govuk-error-message">Complete this section</span></dl>',
+      },
+    });
   });
 
   //SafetyConcerns_yours

--- a/src/main/steps/c100-rebuild/check-your-answers/mainUtil.ts
+++ b/src/main/steps/c100-rebuild/check-your-answers/mainUtil.ts
@@ -1603,17 +1603,58 @@ export const RespondentDetails = (
   const sessionRespondentData = userCase['resp_Respondents'];
   const newRespondentStorage: SummaryListRow[] = [];
   for (const respondent in sessionRespondentData) {
-    const firstname = sessionRespondentData[respondent]['firstName'],
-      lastname = sessionRespondentData[respondent]['lastName'],
+    const firstName = sessionRespondentData[respondent]['firstName'],
+      lastName = sessionRespondentData[respondent]['lastName'],
       id = sessionRespondentData[respondent]['id'],
       personalDetails = sessionRespondentData[respondent]['personalDetails'];
     const isDateOfBirthUnknown = personalDetails['isDateOfBirthUnknown'] !== '';
     const respondentNo = Number(respondent) + 1;
     const contactDetails = sessionRespondentData[respondent]['contactDetails'];
     const respondentFullName =
-      _.isEmpty(firstname) || _.isEmpty(lastname)
+      _.isEmpty(firstName) || _.isEmpty(lastName)
         ? HTML.ERROR_MESSAGE_SPAN + translation('completeSectionError', language) + HTML.SPAN_CLOSE
-        : firstname + ' ' + lastname;
+        : firstName + ' ' + lastName;
+
+    const parseRespondentConfidentiality = () => {
+      const confidentialityQs = {
+        addressConf: sessionRespondentData[respondent]['isRespondentAddressConfidential'],
+        phoneConf: sessionRespondentData[respondent]['isRespondentTelephoneNumberConfidential'],
+        emailConf: sessionRespondentData[respondent]['isRespondentEmailAddressConfidential'],
+      };
+      const hasConfidentialInfo =
+        confidentialityQs.addressConf === YesOrNo.YES ||
+        confidentialityQs.phoneConf === YesOrNo.YES ||
+        confidentialityQs.emailConf === YesOrNo.YES
+          ? YesOrNo.YES
+          : YesOrNo.NO;
+      let html = '';
+      html +=
+        HTML.DESCRIPTION_LIST +
+        (hasConfidentialInfo === YesOrNo.YES ? HTML.ROW_START : HTML.ROW_START_NO_BORDER) +
+        HTML.DESCRIPTION_TERM_DETAIL +
+        populateError(
+          confidentialityQs,
+          getYesNoTranslation(language, hasConfidentialInfo, 'ydwTranslation') +
+            HTML.DESCRIPTION_TERM_DETAIL_END +
+            HTML.ROW_END,
+          language
+        );
+      if (hasConfidentialInfo === YesOrNo.YES) {
+        html += HTML.ROW_START_NO_BORDER + HTML.DESCRIPTION_TERM_DETAIL + HTML.UNORDER_LIST;
+
+        if (confidentialityQs.addressConf === YesOrNo.YES) {
+          html += HTML.LIST_ITEM + content['address'] + HTML.LIST_ITEM_END;
+        }
+        if (confidentialityQs.phoneConf === YesOrNo.YES) {
+          html += HTML.LIST_ITEM + content['telephone'] + HTML.LIST_ITEM_END;
+        }
+        if (confidentialityQs.emailConf === YesOrNo.YES) {
+          html += HTML.LIST_ITEM + content['email'] + HTML.LIST_ITEM_END;
+        }
+        html += HTML.UNORDER_LIST_END + HTML.DESCRIPTION_TERM_DETAIL_END + HTML.ROW_END;
+      }
+      return html + HTML.DESCRIPTION_LIST_END;
+    };
 
     const { changeNameInformation, childGender } = nameAndGenderParser(personalDetails, keys, HTML, language);
     newRespondentStorage.push(
@@ -1734,6 +1775,19 @@ export const RespondentDetails = (
     newRespondentStorage.push(
       ...RespondentDetails_AddressAndPersonal(sessionRespondentData, respondent, keys, id, contactDetails, language)
     );
+    newRespondentStorage.push({
+      key: interpolate(keys['doYouWantToKeepResp'], { firstName, lastName }),
+      visuallyHiddenText: `${keys['respondents']} ${parseInt(respondent) + 1} ${interpolate(
+        keys['doYouWantToKeepResp'],
+        { firstName, lastName }
+      )}`,
+      anchorReference: `doYouWantToKeep-respondent-${respondent}`,
+      value: '',
+      valueHtml: parseRespondentConfidentiality(),
+      changeUrl: applyParms(Urls['C100_RESPONDENT_DETAILS_CONFIDENTIALITY_START_ALTERNATIVE'], {
+        respondentId: sessionRespondentData[respondent]['id'],
+      }),
+    });
   }
 
   const SummaryData = newRespondentStorage;

--- a/src/main/steps/c100-rebuild/check-your-answers/mainUtil.ts
+++ b/src/main/steps/c100-rebuild/check-your-answers/mainUtil.ts
@@ -1775,19 +1775,21 @@ export const RespondentDetails = (
     newRespondentStorage.push(
       ...RespondentDetails_AddressAndPersonal(sessionRespondentData, respondent, keys, id, contactDetails, language)
     );
-    newRespondentStorage.push({
-      key: interpolate(keys['doYouWantToKeepResp'], { firstName, lastName }),
-      visuallyHiddenText: `${keys['respondents']} ${parseInt(respondent) + 1} ${interpolate(
-        keys['doYouWantToKeepResp'],
-        { firstName, lastName }
-      )}`,
-      anchorReference: `doYouWantToKeep-respondent-${respondent}`,
-      value: '',
-      valueHtml: parseRespondentConfidentiality(),
-      changeUrl: applyParms(Urls['C100_RESPONDENT_DETAILS_CONFIDENTIALITY_START_ALTERNATIVE'], {
-        respondentId: sessionRespondentData[respondent]['id'],
-      }),
-    });
+    if (sessionRespondentData.length > 1) {
+      newRespondentStorage.push({
+        key: interpolate(keys['doYouWantToKeepResp'], { firstName, lastName }),
+        visuallyHiddenText: `${keys['respondents']} ${parseInt(respondent) + 1} ${interpolate(
+          keys['doYouWantToKeepResp'],
+          { firstName, lastName }
+        )}`,
+        anchorReference: `doYouWantToKeep-respondent-${respondent}`,
+        value: '',
+        valueHtml: parseRespondentConfidentiality(),
+        changeUrl: applyParms(Urls['C100_RESPONDENT_DETAILS_CONFIDENTIALITY_START_ALTERNATIVE'], {
+          respondentId: sessionRespondentData[respondent]['id'],
+        }),
+      });
+    }
   }
 
   const SummaryData = newRespondentStorage;

--- a/src/main/steps/c100-rebuild/check-your-answers/util/respondent.util.ts
+++ b/src/main/steps/c100-rebuild/check-your-answers/util/respondent.util.ts
@@ -2,7 +2,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { cy as contentAddressCy, en as contentAddressEn } from '../../respondent-details/address/manual/content';
+import {
+  cy as contentStartAlternativeCy,
+  en as contentStartAlternativeEn,
+} from '../../respondent-details/confidentiality/start-alternative/content';
 import { cy as personalDetailsCy, en as personalDetailsEn } from '../../respondent-details/personal-details/content';
+
 /**
  * It returns an object containing the contents of the English and Welsh versions of the page,
  * depending on the language selected
@@ -14,6 +19,7 @@ export const RespondentsElements = SystemLanguage => {
       return {
         ...contentAddressEn(),
         ...personalDetailsEn(),
+        doYouWantToKeepResp: contentStartAlternativeEn.keepContactDetailsPrivate,
         respondentAddressLabel: contentAddressEn().addressHistoryLabel,
         errors: '',
       };
@@ -22,6 +28,7 @@ export const RespondentsElements = SystemLanguage => {
       return {
         ...contentAddressCy(),
         ...personalDetailsCy(),
+        doYouWantToKeepResp: contentStartAlternativeCy.keepContactDetailsPrivate,
         respondentAddressLabel: contentAddressCy().addressHistoryLabel,
         errors: '',
       };


### PR DESCRIPTION
### JIRA link (if applicable) ###
[FPVTL-2270](https://tools.hmcts.net/jira/browse/FPVTL-2270)


### Change description ###
 - Add CYA items for respondents (only if > 1 respondent, otherwise the pages are skipped as per [FPVTL-2528](https://tools.hmcts.net/jira/browse/FPVTL-2528))


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
