### PR TITLE
Tweaking the renovate config to ignore the caret in our package.json …

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,13 +5,15 @@
   "prConcurrentLimit": 25,
   "schedule": ["after 4pm and before 7pm every weekday"],
   "rebaseWhen": "behind-base-branch",
+  "rangeStrategy": "pin",
   "vulnerabilityAlerts": {
     "enabled": true,
     "schedule": "at any time",
     "prConcurrentLimit": 25,
     "vulnerabilityFixStrategy": "lowest",
     "dependencyDashboardApproval": false,
-    "commitMessagePrefix": "SEC-FIX: "
+    "commitMessagePrefix": "SEC-FIX: ",
+    "rangeStrategy": "pin"
   },
   "packageRules": [
     {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A.


### Change description ###
This PR aims to address issues with our current setup re: package.json and lock files:

**1]** Prevents lockfile-only updates (which will ALWAYS fail on the pipeline due to the frozen lockfile req) 2. 
**2]** it allows us to safely move away from caret-based package updates meaning our builds will be more idempotent and we'll slowly become more resilient to silent minor/patch version changes from e.g. typescript


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
