### PR TITLE
FPVTL-2202: Restore smoke tests

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -80,6 +80,10 @@ withPipeline(type, product, component) {
   afterAlways('smoketest:preview') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'output/**/*'
   }
+  before('smoketest:aat') {
+    env.PRL_CITIZEN_URL = "https://prl-citizen-frontend-staging.aat.platform.hmcts.net"
+    build job: 'HMCTS_j_to_z/prl-e2e-tests/master', wait: true, propogate: true, parameters: [booleanParam(name: "skipManageCasesTests", value: true), string(name: "CITIZEN_FRONTEND_BASE_URL", value: env.PRL_CITIZEN_URL)]
+  }
   afterAlways('smoketest:aat') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'output/**/*'
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-2202


### Change description ###
- Restore smoke tests that were temporarily disabled due to them unexpectedly failing during the C8 release
- They were failing because the tests didn't seem to be running the latest version of the test code


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
