### PR TITLE
FPVTL-3069: Log PCQ enabled value

### DIFF
--- a/src/main/modules/pcq/index.ts
+++ b/src/main/modules/pcq/index.ts
@@ -68,7 +68,10 @@ export class PcqProvider {
     });
   }
 
-  async enable(app: Application): Promise<void> {
+  async enable(app: Application, logger?: LoggerInstance): Promise<void> {
+    if (logger) {
+      this.logger = logger;
+    }
     this.isEnabled = await this.isComponentEnabled();
     if (this.isEnabled) {
       this.route.enable(app);
@@ -77,8 +80,9 @@ export class PcqProvider {
 
   async isComponentEnabled(): Promise<boolean> {
     const isEnabled =
-      getFeatureToggle()?.isPcqComponentEnabled() ??
+      (await getFeatureToggle()?.isPcqComponentEnabled()) ??
       toBoolean(config.get<boolean>('featureToggles.enablePcqComponent'));
+    this.logger.info?.(`PCQ component is ${isEnabled ? 'enabled' : 'disabled'}`);
     return new Promise(resolve => {
       resolve(isEnabled);
     });

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -82,7 +82,7 @@ new Routes().enableFor(app);
 new ErrorHandler().handleNextErrorsFor(app);
 new FeatureToggleProvider().enable(app);
 RAProvider.enable(app);
-PCQProvider.enable(app);
+PCQProvider.enable(app, logger);
 
 setupDev(app, developmentMode);
 const port: number = config.get('port');


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-3069


### Change description ###
- Log PCQ enabled value
- This is a temporary update to check the value in staging
- The intention is to rollback once staging value have been checked

Tested in preview on E2E tests. Logs out

```
2026-07-01T15:36:39+00:00 - info: [server] Application started: http://localhost:3001
2026-07-01T15:36:41+00:00 - info: [server] PCQ component is enabled
info: [LaunchDarkly] Opened LaunchDarkly stream connection
courtDetails-----------------{"slug":"childcare-arrangements","name":"Childcare arrangements if you separate from your partner","onlineText":null,"onlineUrl":"https://apply-to-court-about-child-arrangements.service.justice.gov.uk/","courts":[{"name":"Swansea Civil Justice Centre","slug":"swansea-civil-justice-centre","open":true,"distance":1.5,"areasOfLawSpoe":["Children"]}]}
2026-07-01T15:43:24+00:00 - info: [server] PCQ component is enabled
```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
