### PR TITLE
FPVTL-3069: Set PCQ to be enabled by default in chart

### DIFF
--- a/charts/prl-citizen-frontend/Chart.yaml
+++ b/charts/prl-citizen-frontend/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for prl-citizen-frontend App
 name: prl-citizen-frontend
 home: https://github.com/hmcts/prl-citizen-frontend
-version: 0.0.30
+version: 0.0.31
 dependencies:
   - name: nodejs
     version: 3.2.0

--- a/charts/prl-citizen-frontend/values.yaml
+++ b/charts/prl-citizen-frontend/values.yaml
@@ -28,7 +28,7 @@ nodejs:
     TESTING_SUPPORT_FLAG: false
     ENABLE_CASE_TRAIN_TRACK: false
     ENABLE_RA_COMPONENT: false
-    ENABLE_PCQ_COMPONENT: false
+    ENABLE_PCQ_COMPONENT: true
     ALLOWED_COURTS: Swansea Civil Justice Centre,Kingston-upon-Hull Combined Court Centre,Grimsby Combined Court Centre
   keyVaults:
     prl:

--- a/src/main/modules/pcq/index.ts
+++ b/src/main/modules/pcq/index.ts
@@ -68,10 +68,7 @@ export class PcqProvider {
     });
   }
 
-  async enable(app: Application, logger?: LoggerInstance): Promise<void> {
-    if (logger) {
-      this.logger = logger;
-    }
+  async enable(app: Application): Promise<void> {
     this.isEnabled = await this.isComponentEnabled();
     if (this.isEnabled) {
       this.route.enable(app);
@@ -82,7 +79,6 @@ export class PcqProvider {
     const isEnabled =
       (await getFeatureToggle()?.isPcqComponentEnabled()) ??
       toBoolean(config.get<boolean>('featureToggles.enablePcqComponent'));
-    this.logger.info?.(`PCQ component is ${isEnabled ? 'enabled' : 'disabled'}`);
     return new Promise(resolve => {
       resolve(isEnabled);
     });

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -82,7 +82,7 @@ new Routes().enableFor(app);
 new ErrorHandler().handleNextErrorsFor(app);
 new FeatureToggleProvider().enable(app);
 RAProvider.enable(app);
-PCQProvider.enable(app, logger);
+PCQProvider.enable(app);
 
 setupDev(app, developmentMode);
 const port: number = config.get('port');


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-3069


### Change description ###
- PCQ needs to be enabled in staging for the E2E smoke tests to run. Set PCQ to be enabled by default
- PCQ is currently enabled for all other environments in the flux config
- Remove debug logging


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
