### PR TITLE
Update preview env chart pr config to include CDAM

### DIFF
--- a/charts/prl-citizen-frontend/Chart.yaml
+++ b/charts/prl-citizen-frontend/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for prl-citizen-frontend App
 name: prl-citizen-frontend
 home: https://github.com/hmcts/prl-citizen-frontend
-version: 0.0.31
+version: 0.0.32
 dependencies:
   - name: nodejs
     version: 3.2.0

--- a/charts/prl-citizen-frontend/values.preview.template.yaml
+++ b/charts/prl-citizen-frontend/values.preview.template.yaml
@@ -21,7 +21,8 @@ nodejs:
     DOCUMENT_MANAGEMENT_URL: 'http://ccd-case-document-am-api-aat.service.core-compute-aat.internal'
     CCD_URL: 'http://ccd-data-store-api-aat.service.core-compute-aat.internal'
     COS_URL: 'http://prl-cos-aat.service.core-compute-aat.internal'
-    # Uncomment to point to PR specific prl-ccd-definitions and ccd
+    # Uncomment to point to PR specific prl-ccd-definitions and ccd. cdam is also required to view documents
+#    DOCUMENT_MANAGEMENT_URL: 'https://ccd-case-document-am-api-prl-ccd-definitions-pr-3422.preview.platform.hmcts.net'
 #    CCD_URL: 'https://ccd-data-store-api-prl-ccd-definitions-pr-3422.preview.platform.hmcts.net'
 #    COS_URL: 'https://prl-ccd-definitions-pr-3422.preview.platform.hmcts.net'
     FACT_URL: 'http://fact-api-aat.service.core-compute-aat.internal'


### PR DESCRIPTION
### Change description ###
- when pointing preview to a specific cos/ccd defs PR it is necessary to also point it to the specific CDAM service so that documents can be viewed 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
