### PR TITLE
Fixing sonar failures on duplicate code.

### DIFF
--- a/src/main/steps/application-within-proceedings/document-upload/routeGuard.ts
+++ b/src/main/steps/application-within-proceedings/document-upload/routeGuard.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Response } from 'express';
 
-import { caseApi } from '../../../app/case/CaseApi';
 import { AppRequest } from '../../../app/controller/AppRequest';
+import { deleteAWPDocument } from '../utils';
 
 export const routeGuard = {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -20,11 +20,7 @@ export const routeGuard = {
       if (documentToDelete) {
         try {
           req.session.errors = [];
-          const userDetails = req?.session?.user;
-          await caseApi(userDetails, req.locals.logger).deleteDocument(removeId.toString());
-          req.locals.logger.info(
-            `AWP application doc ${removeId} deleted by user ${req.session?.user?.id} on case ${req.session?.userCase?.id}`
-          );
+          await deleteAWPDocument(req, removeId, 'AWP application doc');
         } catch (error) {
           return next();
         }

--- a/src/main/steps/application-within-proceedings/supporting-document-upload/routeGuard.ts
+++ b/src/main/steps/application-within-proceedings/supporting-document-upload/routeGuard.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Response } from 'express';
 
-import { caseApi } from '../../../app/case/CaseApi';
 import { AppRequest } from '../../../app/controller/AppRequest';
+import { deleteAWPDocument } from '../utils';
 
 export const routeGuard = {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -20,11 +20,7 @@ export const routeGuard = {
       if (documentToDelete) {
         try {
           req.session.errors = [];
-          const userDetails = req?.session?.user;
-          await caseApi(userDetails, req.locals.logger).deleteDocument(removeId.toString());
-          req.locals.logger.info(
-            `AWP supporting doc ${removeId} deleted by user ${req.session?.user?.id} on case ${req.session?.userCase?.id}`
-          );
+          await deleteAWPDocument(req, removeId, 'AWP supporting doc');
         } catch (error) {
           return next();
         }

--- a/src/main/steps/application-within-proceedings/utils.ts
+++ b/src/main/steps/application-within-proceedings/utils.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 import _ from 'lodash';
 
+import { caseApi } from '../../app/case/CaseApi';
 import { CosApiClient } from '../../app/case/CosApiClient';
 import { CaseWithId } from '../../app/case/case';
 import {
@@ -438,6 +439,14 @@ export const resetAWPApplicationData = (req: AppRequest): void => {
   delete req.session?.userCase?.awp_urgentRequestReason;
   delete req.session?.userCase?.awp_hasSupportingDocuments;
   delete req.session?.userCase?.awp_supportingDocuments;
+};
+
+export const deleteAWPDocument = async (req: AppRequest, removeId: string, documentLabel: string): Promise<void> => {
+  const userDetails = req?.session?.user;
+  await caseApi(userDetails, req.locals.logger).deleteDocument(removeId.toString());
+  req.locals.logger.info(
+    `${documentLabel} ${removeId} deleted by user ${req.session?.user?.id} on case ${req.session?.userCase?.id}`
+  );
 };
 
 const createAWPApplication = async (


### PR DESCRIPTION
### Change description ###
PR to get master back in the green.
Our PR's don' seem to use the same config as master on SonarCloud. 
This PR removes the duplicate lines that sonar was whinging about.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
